### PR TITLE
[KUBOS-444] Moving bootcount increase until we actually try to boot

### DIFF
--- a/common/autoboot.c
+++ b/common/autoboot.c
@@ -298,9 +298,6 @@ const char *bootdelay_process(void)
 
 #ifdef CONFIG_BOOTCOUNT_LIMIT
 	bootcount = bootcount_load();
-	bootcount++;
-	bootcount_store(bootcount);
-	setenv_ulong("bootcount", bootcount);
 	bootlimit = getenv_ulong("bootlimit", 10, 0);
 #endif /* CONFIG_BOOTCOUNT_LIMIT */
 
@@ -347,6 +344,15 @@ void autoboot_command(const char *s)
 #if defined(CONFIG_AUTOBOOT_KEYED) && !defined(CONFIG_AUTOBOOT_KEYED_CTRLC)
 		int prev = disable_ctrlc(1);	/* disable Control C checking */
 #endif
+
+/* Save the new bootcount if we're actually going to try to boot (vs going to U-Boot shell) */
+#ifdef CONFIG_BOOTCOUNT_LIMIT
+		unsigned long bootcount = 0;
+
+		bootcount = bootcount_load();
+		bootcount++;
+		bootcount_store(bootcount);
+#endif /* CONFIG_BOOTCOUNT_LIMIT */
 
 		run_command_list(s, -1, 0);
 

--- a/common/bootm.c
+++ b/common/bootm.c
@@ -780,7 +780,7 @@ err:
 	 * can track the failure and run the altbootcmd instead, if it's available.
 	 */
 	printf("Boot failed. No rollback could be completed\n");
-	if (getenv_yesno("upgrade_available"))
+	if (getenv_yesno("recovery_available"))
 	{
 		do_reset(cmdtp, flag, argc, argv);
 	}

--- a/common/bootm.c
+++ b/common/bootm.c
@@ -612,7 +612,7 @@ int do_bootm_states(cmd_tbl_t *cmdtp, int flag, int argc, char * const argv[],
 
 #ifdef CONFIG_UPDATE_KUBOS
 	/* Check the boot counter. If it's too high, we need to try and recover */
-	if(bootcount_load() > 1)
+	if(bootcount_load() > 2)
 	{
 		ret = BOOTM_ERR_OTHER;
 		printf("ERROR: Failed to boot too many times, triggering recovery\n");

--- a/common/bootm.c
+++ b/common/bootm.c
@@ -757,7 +757,8 @@ err:
 
 	/*
 	 * If that fails, or this is not our first time here, check if there's something
-	 * to rollback to and try to roll back to it.
+	 * to rollback to and try to roll back to it. This can be a) a previous version,
+	 * and/or b) the base KubOS version.
 	 * (If the current version is already the base version of KubOS, then there's
 	 * nothing to roll back to)
 	 */
@@ -770,6 +771,14 @@ err:
 			do_reset(cmdtp, flag, argc, argv);
 		}
 
+		printf("Boot failed. Reloading base OS\n");
+		setenv(KUBOS_UPDATE_FILE, KUBOS_BASE);
+		if (update_kubos(KUBOS_RECOVER) == KUBOS_OK_REBOOT)
+		{
+			do_reset(cmdtp, flag, argc, argv);
+		}
+
+		/* Save that we tried the base version so that we won't try again later */
 		setenv(KUBOS_CURR_VERSION, KUBOS_BASE);
 		setenv(KUBOS_UPDATE_FILE, "none");
 		saveenv();

--- a/drivers/bootcount/bootcount_env.c
+++ b/drivers/bootcount/bootcount_env.c
@@ -9,9 +9,9 @@
 
 void bootcount_store(ulong a)
 {
-	int upgrade_available = getenv_ulong("upgrade_available", 10, 0);
+	int recovery_available = getenv_ulong("recovery_available", 10, 0);
 
-	if (upgrade_available) {
+	if (recovery_available) {
 		setenv_ulong("bootcount", a);
 		saveenv();
 	}
@@ -19,10 +19,10 @@ void bootcount_store(ulong a)
 
 ulong bootcount_load(void)
 {
-	int upgrade_available = getenv_ulong("upgrade_available", 10, 0);
+	int recovery_available = getenv_ulong("recovery_available", 10, 0);
 	ulong val = 0;
 
-	if (upgrade_available)
+	if (recovery_available)
 		val = getenv_ulong("bootcount", 10, 0);
 
 	return val;

--- a/include/configs/at91sam9g20isis.h
+++ b/include/configs/at91sam9g20isis.h
@@ -200,9 +200,9 @@
 	"\0"
 
 #define CONFIG_EXTRA_ENV_SETTINGS \
-	"altbootcmd=setenv upgrade_available 0; setenv bootcmd; saveenv; "\
+	"altbootcmd=setenv recovery_available 0; setenv bootcmd; saveenv; "\
 				"cp.b 0x100B0000 0x20000000 0x50000; go 0x20000000\0" \
-	"upgrade_available=1\0" \
+	"recovery_available=1\0" \
     "bootlimit=3\0" \
 	KUBOS_CURR_VERSION "=" KUBOS_BASE "\0" \
 	KUBOS_PREV_VERSION "=" KUBOS_BASE "\0" \
@@ -213,9 +213,9 @@
 #else
 
 #define CONFIG_EXTRA_ENV_SETTINGS \
-	"altbootcmd=setenv upgrade_available 0; setenv bootcmd; saveenv; "\
+	"altbootcmd=setenv recovery_available 0; setenv bootcmd; saveenv; "\
 				"cp.b 0x100B0000 0x20000000 0x50000; go 0x20000000\0" \
-	"upgrade_available=1\0" \
+	"recovery_available=1\0" \
     "bootlimit=1\0" \
 
 #endif /* CONFIG_UPDATE_KUBOS */


### PR DESCRIPTION
At the moment, the bootcount is increased fairly early on in U-Boot's boot process. This means that if you decide to abort the boot and go into U-Boot's CLI, that counts towards the bootcount, even though it's not a "bad boot". Also, for some unknown reason, saving the new bootcount value to NOR flash causes U-Boot to be able to undetect a keyboard input indicating that it should abort the boot.

As a result, I've moved the actual bootcount increase/save logic until just after the 'abort boot' check and just before the actual boot commands are executed.

Misc:
* Added missing recovery case 
* Changed the 'upgrade_available' to be 'recovery_available', since it's a more accurate description of what it's used for. The variable indicates that there is an alternate boot command available should the boot limit be exceeded.
* Increased Kubos recovery boot limit from 1 to 2 to allow an additional bad boot (for example if the watchdog just happens to gets starved due to some odd timing).

** DONE PENDING TESTING **