### PR TITLE
[KUBOS-446] Not updating curr_version if updating NOR flash files

### DIFF
--- a/common/update_kubos.c
+++ b/common/update_kubos.c
@@ -232,9 +232,16 @@ int update_kubos(bool upgrade)
 
 				if (upgrade)
 				{
-					char *version = getenv(KUBOS_CURR_VERSION);
-					setenv(KUBOS_PREV_VERSION, version);
-					setenv(KUBOS_CURR_TRIED, "0");
+					/*
+					 * Only mark that we're using a new version of KubOS Linux if we're doing
+					 * a regular upgrade (vs upgrading NOR flash files)
+					 */
+					if (strstr(file,"nor") == NULL)
+					{
+						char *version = getenv(KUBOS_CURR_VERSION);
+						setenv(KUBOS_PREV_VERSION, version);
+						setenv(KUBOS_CURR_TRIED, "0");
+					}
 				}
 				else
 				{


### PR DESCRIPTION
Fixed upgrade logic to not change kubos_curr_version if upgrading the NOR flash files (since they're not directly related to the KubOS Linux kernel/rootfs)