### PR TITLE
Removing attempt to boot into altos from altbootcmd

### DIFF
--- a/include/configs/at91sam9g20isis.h
+++ b/include/configs/at91sam9g20isis.h
@@ -200,8 +200,7 @@
 	"\0"
 
 #define CONFIG_EXTRA_ENV_SETTINGS \
-	"altbootcmd=setenv recovery_available 0; setenv bootcmd; saveenv; "\
-				"cp.b 0x10090000 0x20000000 0x70000; go 0x20000000\0" \
+	"altbootcmd=setenv recovery_available 0; setenv bootcmd; saveenv\0" \
 	"recovery_available=1\0" \
     "bootlimit=3\0" \
 	KUBOS_CURR_VERSION "=" KUBOS_BASE "\0" \
@@ -213,8 +212,7 @@
 #else
 
 #define CONFIG_EXTRA_ENV_SETTINGS \
-	"altbootcmd=setenv recovery_available 0; setenv bootcmd; saveenv; "\
-				"cp.b 0x10090000 0x20000000 0x70000; go 0x20000000\0" \
+	"altbootcmd=setenv recovery_available 0; setenv bootcmd; saveenv\0" \
 	"recovery_available=1\0" \
     "bootlimit=1\0" \
 


### PR DESCRIPTION
There currently isn't an alternate OS for the iOBC to boot into, so we should never try to boot into something that's not there. The alternate boot command (taken if Kubos recovery is turned on and we've had too many failed boot attempts in a row) will:
  - wipe out the current bootcmd (so we stop trying to boot into a bad OS at startup)
  - turn off Kubos recovery
  - go to the U-Boot CLI