### PR TITLE
Fixing KubOS Update

### DIFF
--- a/common/env_ext4.c
+++ b/common/env_ext4.c
@@ -83,7 +83,7 @@ int saveenv(void)
 		return 1;
 	}
 
-	puts("done\n");
+	debug("done\n");
 	return 0;
 }
 #endif /* CONFIG_CMD_SAVEENV */

--- a/common/env_ext4.c
+++ b/common/env_ext4.c
@@ -83,7 +83,7 @@ int saveenv(void)
 		return 1;
 	}
 
-	debug("done\n");
+	printf("Successfully updated envars\n");
 	return 0;
 }
 #endif /* CONFIG_CMD_SAVEENV */

--- a/common/update_kubos.c
+++ b/common/update_kubos.c
@@ -185,6 +185,8 @@ int update_kubos(bool upgrade)
 		 * update_kubos_count will cause the file system to be closed,
 		 * so we need to remount it.
 		 */
+
+		ext4fs_set_blk_dev(&mmc->block_dev, &part_info);
 		ret = ext4fs_mount(0);
 		if (!ret) {
 

--- a/common/update_kubos.c
+++ b/common/update_kubos.c
@@ -188,7 +188,7 @@ int update_kubos(bool upgrade)
 		ret = ext4fs_mount(0);
 		if (!ret) {
 
-			printf("ERROR: Could not mount upgrade partition. ext4fs mount err - %d\n", ret);
+			printf("ERROR: Could not re-mount upgrade partition. ext4fs mount err - %d\n", ret);
 			return KUBOS_ERR_NO_REBOOT;
 		}
 

--- a/common/update_kubos.c
+++ b/common/update_kubos.c
@@ -55,12 +55,14 @@ int update_kubos_count(void)
 			count++;
 			setenv_ulong(UPDATE_COUNT_ENVAR, count);
 
-			/* Don't let our update attempts count against our boot attempt limit */
-			bootcount = bootcount_load();
-			bootcount--;
-			bootcount_store(bootcount);
+
 		}
 	}
+
+	/* Don't let our update attempts count against our boot attempt limit */
+	bootcount = bootcount_load();
+	bootcount--;
+	bootcount_store(bootcount);
 
 	saveenv();
 	return ret;

--- a/drivers/dfu/dfu_mmc.c
+++ b/drivers/dfu/dfu_mmc.c
@@ -95,9 +95,10 @@ static int mmc_block_op(enum dfu_op op, struct dfu_entity *dfu,
 static int mmc_file_buffer(struct dfu_entity *dfu, void *buf, long *len)
 {
 	if (dfu_file_buf_len + *len > CONFIG_SYS_DFU_MAX_FILE_SIZE) {
+		printf("%s: File '%s' exceeds max file size. %d > %d\n", __func__,
+				       dfu->name, (dfu_file_buf_len + *len), CONFIG_SYS_DFU_MAX_FILE_SIZE);
+
 		dfu_file_buf_len = 0;
-		printf("%s: File buffer exceeds max file size. %d + %d > %d\n", __func__,
-				       dfu_file_buf_len, *len, CONFIG_SYS_DFU_MAX_FILE_SIZE);
 		return -EINVAL;
 	}
 

--- a/drivers/dfu/dfu_mmc.c
+++ b/drivers/dfu/dfu_mmc.c
@@ -96,6 +96,8 @@ static int mmc_file_buffer(struct dfu_entity *dfu, void *buf, long *len)
 {
 	if (dfu_file_buf_len + *len > CONFIG_SYS_DFU_MAX_FILE_SIZE) {
 		dfu_file_buf_len = 0;
+		printf("%s: File buffer exceeds max file size. %d + %d > %d\n", __func__,
+				       dfu_file_buf_len, *len, CONFIG_SYS_DFU_MAX_FILE_SIZE);
 		return -EINVAL;
 	}
 

--- a/fs/ext4/ext4_common.c
+++ b/fs/ext4/ext4_common.c
@@ -889,7 +889,7 @@ static int unlink_filename(char *filename, unsigned int blknr)
 		if (dir->inode && (strlen(filename) == dir->namelen) &&
 		    (strncmp(ptr + sizeof(struct ext2_dirent),
 			     filename, dir->namelen) == 0)) {
-			printf("file found, deleting\n");
+			debug("file found, deleting\n");
 			inodeno = le32_to_cpu(dir->inode);
 			if (previous_dir) {
 				uint16_t new_len;

--- a/fs/ext4/ext4_journal.c
+++ b/fs/ext4/ext4_journal.c
@@ -426,7 +426,7 @@ int ext4fs_check_journal_state(int recovery_flag)
 
 	if (le32_to_cpu(fs->sb->feature_incompat) & EXT3_FEATURE_INCOMPAT_RECOVER) {
 		if (recovery_flag == RECOVER)
-			printf("Recovery required\n");
+			debug("Recovery required\n");
 	} else {
 		if (recovery_flag == RECOVER)
 			debug("File System is consistent\n");

--- a/fs/ext4/ext4_journal.c
+++ b/fs/ext4/ext4_journal.c
@@ -216,11 +216,11 @@ void print_revoke_blks(char *revk_blk)
 	header = (struct journal_revoke_header_t *) revk_blk;
 	offset = sizeof(struct journal_revoke_header_t);
 	max = be32_to_cpu(header->r_count);
-	printf("total bytes %d\n", max);
+	debug("total bytes %d\n", max);
 
 	while (offset < max) {
 		blocknr = be32_to_cpu(*((__be32 *)(revk_blk + offset)));
-		printf("revoke blknr is %ld\n", blocknr);
+		debug("revoke blknr is %ld\n", blocknr);
 		offset += 4;
 	}
 }
@@ -386,9 +386,9 @@ fail:
 void print_jrnl_status(int recovery_flag)
 {
 	if (recovery_flag == RECOVER)
-		printf("Journal Recovery Completed\n");
+		debug("Journal Recovery Completed\n");
 	else
-		printf("Journal Scan Completed\n");
+		debug("Journal Scan Completed\n");
 }
 
 int ext4fs_check_journal_state(int recovery_flag)
@@ -429,7 +429,7 @@ int ext4fs_check_journal_state(int recovery_flag)
 			printf("Recovery required\n");
 	} else {
 		if (recovery_flag == RECOVER)
-			printf("File System is consistent\n");
+			debug("File System is consistent\n");
 		goto end;
 	}
 
@@ -656,5 +656,5 @@ void ext4fs_update_journal(void)
 	}
 	blknr = read_allocated_block(&inode_journal, jrnl_blk_idx++);
 	update_commit_block(blknr);
-	printf("update journal finished\n");
+	debug("update journal finished\n");
 }

--- a/fs/ext4/ext4_write.c
+++ b/fs/ext4/ext4_write.c
@@ -27,6 +27,7 @@
 #include <linux/stat.h>
 #include <div64.h>
 #include "ext4_common.h"
+#include <watchdog.h>
 
 static inline void ext4fs_sb_free_inodes_inc(struct ext2_sblock *sb)
 {

--- a/fs/ext4/ext4_write.c
+++ b/fs/ext4/ext4_write.c
@@ -777,6 +777,13 @@ static int ext4fs_write_file(struct ext2_inode *file_inode,
 		long int blknr;
 		int blockend = fs->blksz;
 		int skipfirst = 0;
+
+#ifdef CONFIG_AT91SAM9G20ISIS
+		WATCHDOG_RESET_COUNT(1000);
+#else
+		WATCHDOG_RESET();
+#endif
+
 		blknr = read_allocated_block(file_inode, i);
 		if (blknr <= 0)
 			return -1;

--- a/include/configs/at91sam9g20isis.h
+++ b/include/configs/at91sam9g20isis.h
@@ -85,7 +85,7 @@
 #ifdef CONFIG_UPDATE_KUBOS
 #define CONFIG_USB_FUNCTION_DFU
 #define CONFIG_SYS_DFU_DATA_BUF_SIZE 500 * SZ_1K /* File transfer chunk size */
-#define CONFIG_SYS_DFU_MAX_FILE_SIZE 3 * SZ_1M   /* Maximum size for a single file.  Currently zImage + rootfs */
+#define CONFIG_SYS_DFU_MAX_FILE_SIZE 4 * SZ_1M   /* Maximum size for a single file.  Currently zImage (~2.5M) */
 #endif
 
 /*

--- a/include/configs/at91sam9g20isis.h
+++ b/include/configs/at91sam9g20isis.h
@@ -85,7 +85,7 @@
 #ifdef CONFIG_UPDATE_KUBOS
 #define CONFIG_USB_FUNCTION_DFU
 #define CONFIG_SYS_DFU_DATA_BUF_SIZE 500 * SZ_1K /* File transfer chunk size */
-#define CONFIG_SYS_DFU_MAX_FILE_SIZE 2 * SZ_1M   /* Maximum size for a single file.  Currently zImage (~1M) */
+#define CONFIG_SYS_DFU_MAX_FILE_SIZE 3 * SZ_1M   /* Maximum size for a single file.  Currently zImage + rootfs */
 #endif
 
 /*


### PR DESCRIPTION
Migrating the uboot envar area to the SD card (plus another recent change) caused some problems with the KubOS update process.

Also, added another watchdog kick, because while ext4_read already had one, ext4_write did not...

Recent kernel changes have increased its file size from 1.7MB to 2.5MB, exceeding the current firmware update max file size of 2MB. Increasing the max size to 4MB to fix it.

Misc:
- Converted some ext4 printf's to debug's, because they're fairly useless informational messages (debug messages are displayed by recompiling the module with "#define DEBUG 1" at the top).