### PR TITLE
Adding Pumpkin MBM2

### DIFF
--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -130,6 +130,15 @@ choice
 	prompt "Target select"
 	default TARGET_HIKEY
 
+config TARGET_PUMPKIN_MBM2
+	bool "Support Pumpkin MBM2"
+	select CPU_V7
+	select SUPPORT_SPL
+	select DM
+	select DM_SERIAL
+	select DM_GPIO
+	select TI_I2C_BOARD_DETECT
+
 config ARCH_AT91
 	bool "Atmel AT91"
 
@@ -1048,6 +1057,7 @@ source "board/h2200/Kconfig"
 source "board/hisilicon/hikey/Kconfig"
 source "board/imx31_phycore/Kconfig"
 source "board/isee/igep0033/Kconfig"
+source "board/kubos/pumpkin-mbm2/Kconfig"
 source "board/mpl/vcma9/Kconfig"
 source "board/olimex/mx23_olinuxino/Kconfig"
 source "board/phytec/pcm051/Kconfig"

--- a/board/kubos/pumpkin-mbm2/Kconfig
+++ b/board/kubos/pumpkin-mbm2/Kconfig
@@ -13,7 +13,7 @@ config SYS_BOARD
 	default "pumpkin-mbm2"
 
 config SYS_VENDOR
-	default "pumpkin"
+	default "kubos"
 
 config SYS_SOC
 	default "am33xx"

--- a/board/kubos/pumpkin-mbm2/Kconfig
+++ b/board/kubos/pumpkin-mbm2/Kconfig
@@ -1,0 +1,36 @@
+if TARGET_PUMPKIN_MBM2
+
+config SPL_ENV_SUPPORT
+	default y
+
+config SPL_WATCHDOG_SUPPORT
+	default y
+
+config SPL_YMODEM_SUPPORT
+	default y
+
+config SYS_BOARD
+	default "pumpkin-mbm2"
+
+config SYS_VENDOR
+	default "pumpkin"
+
+config SYS_SOC
+	default "am33xx"
+
+config SYS_CONFIG_NAME
+	default "pumpkin-mbm2"
+
+config CONS_INDEX
+	int "UART used for console"
+	range 1 6
+	default 1
+	help
+	  The AM335x SoC has a total of 6 UARTs (UART0 to UART5 as referenced
+	  in documentation, etc) available to it.  Depending on your specific
+	  board you may want something other than UART0 as for example the IDK
+	  uses UART3 so enter 4 here.
+
+source "board/ti/common/Kconfig"
+
+endif

--- a/board/kubos/pumpkin-mbm2/Makefile
+++ b/board/kubos/pumpkin-mbm2/Makefile
@@ -15,6 +15,5 @@
 # limitations under the License.
 #
 
-obj-y	+= at91sam9g20isis.o
-obj-y	+= led.o
+obj-y	+= ../../ti/am335x/board.o
 

--- a/board/kubos/pumpkin-mbm2/Makefile
+++ b/board/kubos/pumpkin-mbm2/Makefile
@@ -14,6 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# For the moment, there are no differences between the MBM2 and a regular
+# Beaglebone Black, so just use the existing code for it.
 
-obj-y	+= ../../ti/am335x/board.o
+obj-y	+= ../../ti/am335x/
+obj-y   += ../../ti/common/
+
 

--- a/board/kubos/pumpkin-mbm2/Makefile
+++ b/board/kubos/pumpkin-mbm2/Makefile
@@ -1,0 +1,20 @@
+#
+# KubOS Linux
+# Copyright (C) 2016 Kubos Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+obj-y	+= at91sam9g20isis.o
+obj-y	+= led.o
+

--- a/board/kubos/pumpkin-mbm2/Makefile
+++ b/board/kubos/pumpkin-mbm2/Makefile
@@ -19,6 +19,6 @@
 
 obj-y	+= ../../ti/am335x/board.o
 obj-y	+= ../../ti/am335x/mux.o
-obj-y   += ../../ti/common/board_detect.o
+obj-y	+= ../../ti/common/board_detect.o
 
 

--- a/board/kubos/pumpkin-mbm2/Makefile
+++ b/board/kubos/pumpkin-mbm2/Makefile
@@ -17,7 +17,8 @@
 # For the moment, there are no differences between the MBM2 and a regular
 # Beaglebone Black, so just use the existing code for it.
 
-obj-y	+= ../../ti/am335x/
-obj-y   += ../../ti/common/
+obj-y	+= ../../ti/am335x/board.o
+obj-y	+= ../../ti/am335x/mux.o
+obj-y   += ../../ti/common/board_detect.o
 
 

--- a/drivers/dfu/Kconfig
+++ b/drivers/dfu/Kconfig
@@ -8,6 +8,7 @@ config USB_FUNCTION_DFU
 	
 config UPDATE_KUBOS
 	bool "Kubos kpack support"
+	selects USB_FUNCTION_DFU
 	help
 	  This option allows performing update of DFU-managed medium with data
 	  packaged in Kubos "kpack" files. 

--- a/drivers/dfu/Kconfig
+++ b/drivers/dfu/Kconfig
@@ -8,7 +8,7 @@ config USB_FUNCTION_DFU
 	
 config UPDATE_KUBOS
 	bool "Kubos kpack support"
-	selects USB_FUNCTION_DFU
+	select USB_FUNCTION_DFU
 	help
 	  This option allows performing update of DFU-managed medium with data
 	  packaged in Kubos "kpack" files. 

--- a/include/configs/at91sam9g20isis.h
+++ b/include/configs/at91sam9g20isis.h
@@ -59,8 +59,6 @@
 #define CONFIG_SKIP_LOWLEVEL_INIT
 #define CONFIG_BOARD_EARLY_INIT_F
 #define CONFIG_DISPLAY_CPUINFO
-#define CONFIG_BOOTCOUNT_LIMIT
-#define CONFIG_BOOTCOUNT_ENV
 
 /* general purpose I/O */
 #define CONFIG_ATMEL_LEGACY		/* required until (g)pio is fixed */

--- a/include/configs/at91sam9g20isis.h
+++ b/include/configs/at91sam9g20isis.h
@@ -29,6 +29,8 @@
 #include <linux/sizes.h>
 #include <linux/kconfig.h>
 
+#include "kubos-common.h"
+
 /*
  * CONFIG_SYS_TEXT_BASE - The starting address of U-Boot.
  * Warning: changing CONFIG_SYS_TEXT_BASE requires
@@ -83,9 +85,23 @@
 
 /* File updates */
 #ifdef CONFIG_UPDATE_KUBOS
-#define CONFIG_USB_FUNCTION_DFU
 #define CONFIG_SYS_DFU_DATA_BUF_SIZE 500 * SZ_1K /* File transfer chunk size */
 #define CONFIG_SYS_DFU_MAX_FILE_SIZE 4 * SZ_1M   /* Maximum size for a single file.  Currently zImage (~2.5M) */
+
+/* DFU Configuration */
+#define DFU_ALT_INFO_MMC \
+	"dfu_alt_info_mmc=" 		\
+	"kernel fat 0 5;" 		\
+	"rootfs part 0 6\0"
+
+#define DFU_ALT_INFO_NOR \
+	"dfu_alt_info_nor="		    \
+	"uboot raw 0xA000 0x56000;" \
+	"dtb raw 0x70000 0x10000" \
+	"\0"
+#else
+#define DFU_ALT_INFO_MMC ""
+#define DFU_ALT_INFO_NOR ""
 #endif
 
 /*
@@ -159,17 +175,6 @@
 #define CONFIG_SYS_USB_OHCI_SLOT_NAME		"at91sam9g20"
 #define CONFIG_SYS_USB_OHCI_MAX_ROOT_PORTS	2
 
-/* Update Definitions */
-#ifdef CONFIG_UPDATE_KUBOS
-
-#define KUBOS_CURR_VERSION "kubos_curr_version"
-#define KUBOS_PREV_VERSION "kubos_prev_version"
-#define KUBOS_CURR_TRIED   "kubos_curr_tried"
-#define KUBOS_BASE         "kpack-base.itb"
-#define KUBOS_UPDATE_FILE  "kubos_updatefile"
-
-#endif
-
 #define CONFIG_SYS_LOAD_ADDR			0x21880000	/* load address to load zImage to */
 
 #define CONFIG_SYS_MEMTEST_START		CONFIG_SYS_SDRAM_BASE
@@ -188,38 +193,8 @@
 	"console=ttyS0,115200 "				\
 	"root=/dev/mmcblk0p6 rootwait"
 
-#ifdef CONFIG_UPDATE_KUBOS
-
-/* DFU Configuration */
-#define DFU_ALT_INFO_MMC \
-	"dfu_alt_info_mmc=" 		\
-	"kernel fat 0 5;" 		\
-	"rootfs part 0 6\0"
-
-#define DFU_ALT_INFO_NOR \
-	"dfu_alt_info_nor="		    \
-	"uboot raw 0xA000 0x56000;" \
-	"dtb raw 0x70000 0x10000" \
-	"\0"
-
 #define CONFIG_EXTRA_ENV_SETTINGS \
-	"altbootcmd=setenv recovery_available 0; setenv bootcmd; saveenv\0" \
-	"recovery_available=1\0" \
-    "bootlimit=3\0" \
-	KUBOS_CURR_VERSION "=" KUBOS_BASE "\0" \
-	KUBOS_PREV_VERSION "=" KUBOS_BASE "\0" \
-	KUBOS_CURR_TRIED "=0\0" \
-	DFU_ALT_INFO_MMC \
-	DFU_ALT_INFO_NOR
-
-#else
-
-#define CONFIG_EXTRA_ENV_SETTINGS \
-	"altbootcmd=setenv recovery_available 0; setenv bootcmd; saveenv\0" \
-	"recovery_available=1\0" \
-    "bootlimit=1\0" \
-
-#endif /* CONFIG_UPDATE_KUBOS */
+	KUBOS_UPDATE_ARGS
 
 #define CONFIG_SYS_FLASH_CFI			1
 #define CONFIG_FLASH_CFI_DRIVER			1
@@ -231,7 +206,7 @@
  */
 #define CONFIG_SYS_MAX_FLASH_SECT		23
 #define CONFIG_SYS_MAX_FLASH_BANKS		1
-#endif
+#endif /* CONFIG_SYS_USE_NORFLASH */
 
 #define CONFIG_SYS_CBSIZE		256
 #define CONFIG_SYS_MAXARGS		16

--- a/include/configs/kubos-common.h
+++ b/include/configs/kubos-common.h
@@ -23,8 +23,8 @@
  * - DFU_ALT_INFO_MMC - Defines the files/partitions which may be replaced in MMC
  *                      storage
  * - DFU_ALT_INFO_NOR - Same as above, but for NOR flash storage
- * - CONFIG_SYS_DFU_DATA_BUF_SIZE - File transfer chunk size (for non-raw file transfer. EXT4, FAT, etc)
- * - CONFIG_SYS_DFU_MAX_FILE_SIZE - Max size for a single file (raw file transfer)
+ * - CONFIG_SYS_DFU_DATA_BUF_SIZE - File transfer chunk size (for raw or file transfer. EXT4, FAT, etc)
+ * - CONFIG_SYS_DFU_MAX_FILE_SIZE - Max size for a single file (partition transfer)
  */
 
 #pragma once

--- a/include/configs/kubos-common.h
+++ b/include/configs/kubos-common.h
@@ -1,0 +1,55 @@
+/*
+* Copyright (C) 2017 Kubos Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/*
+ * These are the settings needed for the Kubos Software Update/Recovery system.
+ * Everything defined here is expected to be common to all boards. There are some
+ * options that must be defined in the board's configuration file because they are
+ * not guaranteed to be portable:
+ *
+ * - DFU_ALT_INFO_MMC - Defines the files/partitions which may be replaced in MMC
+ *                      storage
+ * - DFU_ALT_INFO_NOR - Same as above, but for NOR flash storage
+ * - CONFIG_SYS_DFU_DATA_BUF_SIZE - File transfer chunk size (for non-raw file transfer. EXT4, FAT, etc)
+ * - CONFIG_SYS_DFU_MAX_FILE_SIZE - Max size for a single file (raw file transfer)
+ */
+
+#pragma once
+
+#ifdef CONFIG_UPDATE_KUBOS
+
+/* Update Definitions */
+#define KUBOS_CURR_VERSION "kubos_curr_version"
+#define KUBOS_PREV_VERSION "kubos_prev_version"
+#define KUBOS_CURR_TRIED   "kubos_curr_tried"
+#define KUBOS_BASE         "kpack-base.itb"
+#define KUBOS_UPDATE_FILE  "kubos_updatefile"
+
+#define KUBOS_UPDATE_ARGS \
+	"altbootcmd=setenv recovery_available 0; setenv bootcmd; saveenv\0" \
+	"recovery_available=1\0" \
+    "bootlimit=3\0" \
+	KUBOS_CURR_VERSION "=" KUBOS_BASE "\0" \
+	KUBOS_PREV_VERSION "=" KUBOS_BASE "\0" \
+	KUBOS_CURR_TRIED "=0\0" \
+	DFU_ALT_INFO_MMC \
+	DFU_ALT_INFO_NOR
+
+#else
+
+#define KUBOS_UPDATE_ARGS ""
+
+#endif /* CONFIG_UPDATE_KUBOS */

--- a/include/configs/kubos-common.h
+++ b/include/configs/kubos-common.h
@@ -30,6 +30,8 @@
 #pragma once
 
 #ifdef CONFIG_UPDATE_KUBOS
+#define CONFIG_BOOTCOUNT_LIMIT
+#define CONFIG_BOOTCOUNT_ENV
 
 /* Update Definitions */
 #define KUBOS_CURR_VERSION "kubos_curr_version"

--- a/include/configs/pumpkin-mbm2.h
+++ b/include/configs/pumpkin-mbm2.h
@@ -29,6 +29,7 @@
 #undef CONFIG_ENV_SIZE
 #undef DFU_ALT_INFO_MMC
 #undef DFU_ALT_INFO_NOR
+#undef CONFIG_BOOTCOUNT_AM33XX
 /* End of undefs */
 
 #if defined(CONFIG_SPL_BUILD) && defined(CONFIG_SPL_USBETH_SUPPORT)
@@ -50,7 +51,7 @@
 #define EXT4_ENV_INTERFACE       "mmc"
 #define EXT4_ENV_DEVICE_AND_PART "0:3" /* TODO */
 #define EXT4_ENV_FILE            "/system/etc/uboot.env"
-#define CONFIG_ENV_SIZE         1 * 1024 /* Assume sector size of 1024 */
+#define CONFIG_ENV_SIZE         10 * 1024 /* Assume sector size of 1024 */
 #endif
 
 #endif /* CONFIG_SPL_BUILD */

--- a/include/configs/pumpkin-mbm2.h
+++ b/include/configs/pumpkin-mbm2.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <configs/am333x_evm.h>
+#include "am335x_evm.h"
 
 /* File updates */
 #ifdef CONFIG_UPDATE_KUBOS

--- a/include/configs/pumpkin-mbm2.h
+++ b/include/configs/pumpkin-mbm2.h
@@ -17,15 +17,37 @@
 #pragma once
 
 #include "am335x_evm.h"
+#include "kubos-common.h"
 
 /* Undo things we don't want to include from the base Beaglebone Black configuration */
 #undef CONFIG_SYS_LDSCRIPT /* For NOR flash, which we (and the BBB) don't support */
 #undef CONFIG_BOOTCOMMAND
+#undef CONFIG_EXTRA_ENV_SETTINGS
+/* End of undefs */
+
+/* File updates */
+#ifdef CONFIG_UPDATE_KUBOS
+#define CONFIG_SYS_DFU_DATA_BUF_SIZE 500 * SZ_1K /* File transfer chunk size */
+#define CONFIG_SYS_DFU_MAX_FILE_SIZE 4 * SZ_1M   /* Maximum size for a single file.  Currently zImage (~2.5M) */
+
+/* DFU Configuration */
+#define DFU_ALT_INFO_MMC \
+	"dfu_alt_info_mmc=" 		\
+	"kernel fat 0 5;" 		\
+	"rootfs part 0 6\0"
+
+#define DFU_ALT_INFO_NOR \
+	"dfu_alt_info_nor="		    \
+	"uboot raw 0xA000 0x56000;" \
+	"dtb raw 0x70000 0x10000" \
+	"\0"
+#else
+#define DFU_ALT_INFO_MMC ""
+#define DFU_ALT_INFO_NOR ""
+#endif
 
 #define CONFIG_BOOTCOMMAND \
 	"run distro_bootcmd"
-
-#undef CONFIG_EXTRA_ENV_SETTINGS
 
 #define CONFIG_EXTRA_ENV_SETTINGS \
 	DEFAULT_LINUX_BOOT_ENV \
@@ -53,57 +75,7 @@
 		"fi;\0" \
 	NETARGS \
 	DFUARGS \
-	BOOTENV
+	BOOTENV \
+	KUBOS_UPDATE_ARGS
 #endif
 
-/* File updates */
-#ifdef CONFIG_UPDATE_KUBOS
-#define CONFIG_SYS_DFU_DATA_BUF_SIZE 500 * SZ_1K /* File transfer chunk size */
-#define CONFIG_SYS_DFU_MAX_FILE_SIZE 4 * SZ_1M   /* Maximum size for a single file.  Currently zImage (~2.5M) */
-#endif
-
-/* Update Definitions */
-#ifdef CONFIG_UPDATE_KUBOS
-
-#define KUBOS_CURR_VERSION "kubos_curr_version"
-#define KUBOS_PREV_VERSION "kubos_prev_version"
-#define KUBOS_CURR_TRIED   "kubos_curr_tried"
-#define KUBOS_BASE         "kpack-base.itb"
-#define KUBOS_UPDATE_FILE  "kubos_updatefile"
-
-#endif
-
-#ifdef TEMP_FAKE_DEFINE
-#ifdef CONFIG_UPDATE_KUBOS
-
-/* DFU Configuration */
-#define DFU_ALT_INFO_MMC \
-	"dfu_alt_info_mmc=" 		\
-	"kernel fat 0 5;" 		\
-	"rootfs part 0 6\0"
-
-#define DFU_ALT_INFO_NOR \
-	"dfu_alt_info_nor="		    \
-	"uboot raw 0xA000 0x56000;" \
-	"dtb raw 0x70000 0x10000" \
-	"\0"
-
-#define CONFIG_EXTRA_ENV_SETTINGS \
-	"altbootcmd=setenv recovery_available 0; setenv bootcmd; saveenv\0" \
-	"recovery_available=1\0" \
-    "bootlimit=3\0" \
-	KUBOS_CURR_VERSION "=" KUBOS_BASE "\0" \
-	KUBOS_PREV_VERSION "=" KUBOS_BASE "\0" \
-	KUBOS_CURR_TRIED "=0\0" \
-	DFU_ALT_INFO_MMC \
-	DFU_ALT_INFO_NOR
-
-#else
-
-#define CONFIG_EXTRA_ENV_SETTINGS \
-	"altbootcmd=setenv recovery_available 0; setenv bootcmd; saveenv\0" \
-	"recovery_available=1\0" \
-    "bootlimit=1\0" \
-
-#endif /* CONFIG_UPDATE_KUBOS */
-#endif /* Placeholder */

--- a/include/configs/pumpkin-mbm2.h
+++ b/include/configs/pumpkin-mbm2.h
@@ -26,7 +26,7 @@
 #undef CONFIG_ENV_IS_IN_MMC
 #undef CONFIG_ENV_IS_IN_FAT
 #undef CONFIG_ENV_IS_NOWHERE
-#undef CONFIG_ENV_SIZE
+/* #undef CONFIG_ENV_SIZE */ /* uncomment after removing temporary */
 #undef DFU_ALT_INFO_MMC
 #undef DFU_ALT_INFO_NOR
 /* End of undefs */

--- a/include/configs/pumpkin-mbm2.h
+++ b/include/configs/pumpkin-mbm2.h
@@ -41,7 +41,6 @@
 #undef CONFIG_EFI_PARTITION
 #else
 
-#if 0 /* temporary */
 /* EXT4 */
 #ifdef CONFIG_CMD_EXT4
 #define CONFIG_EXT4_WRITE
@@ -53,13 +52,7 @@
 #define EXT4_ENV_FILE            "/system/etc/uboot.env"
 #define CONFIG_ENV_SIZE         1 * 1024 /* Assume sector size of 1024 */
 #endif
-#else
 
-#define CONFIG_ENV_IS_IN_FAT
-#define FAT_ENV_INTERFACE		"mmc"
-#define FAT_ENV_DEVICE_AND_PART		"0:1"
-#define FAT_ENV_FILE			"uboot.env"
-#endif /* temporary */
 #endif /* CONFIG_SPL_BUILD */
 
 /* File updates */

--- a/include/configs/pumpkin-mbm2.h
+++ b/include/configs/pumpkin-mbm2.h
@@ -26,7 +26,7 @@
 #undef CONFIG_ENV_IS_IN_MMC
 #undef CONFIG_ENV_IS_IN_FAT
 #undef CONFIG_ENV_IS_NOWHERE
-/* #undef CONFIG_ENV_SIZE */ /* uncomment after removing temporary */
+#undef CONFIG_ENV_SIZE
 #undef DFU_ALT_INFO_MMC
 #undef DFU_ALT_INFO_NOR
 /* End of undefs */

--- a/include/configs/pumpkin-mbm2.h
+++ b/include/configs/pumpkin-mbm2.h
@@ -84,7 +84,7 @@
 
 #define CONFIG_BOOTARGS \
 	"console=ttyS0,115200 "				\
-	"root=/dev/mmcblk0p2 ext4 rootwait"
+	"root=/dev/mmcblk1p2 ext4 rootwait"
 
 #ifndef CONFIG_SPL_BUILD
 #define CONFIG_EXTRA_ENV_SETTINGS \

--- a/include/configs/pumpkin-mbm2.h
+++ b/include/configs/pumpkin-mbm2.h
@@ -1,0 +1,262 @@
+/*
+ * pumpkin-mbm2.h
+ *
+ * Copyright (C) 2011 Texas Instruments Incorporated - http://www.ti.com/
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation version 2.
+ *
+ * This program is distributed "as is" WITHOUT ANY WARRANTY of any
+ * kind, whether express or implied; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#pragma once
+
+#include <configs/ti_am335x_common.h>
+
+#ifndef CONFIG_SPL_BUILD
+# define CONFIG_TIMESTAMP
+# define CONFIG_LZO
+#endif
+
+#define CONFIG_SYS_BOOTM_LEN		(16 << 20)
+
+#define MACH_TYPE_TIAM335EVM		3589	/* Until the next sync */
+#define CONFIG_MACH_TYPE		MACH_TYPE_TIAM335EVM
+#define CONFIG_BOARD_LATE_INIT
+
+/* Clock Defines */
+#define V_OSCK				24000000  /* Clock output from T2 */
+#define V_SCLK				(V_OSCK)
+
+/* Always 128 KiB env size */
+#define CONFIG_ENV_SIZE			(128 << 10)
+
+/* Enhance our eMMC support / experience. */
+#define CONFIG_CMD_GPT
+#define CONFIG_EFI_PARTITION
+
+/* File updates */
+#ifdef CONFIG_UPDATE_KUBOS
+#define CONFIG_USB_FUNCTION_DFU
+#define CONFIG_SYS_DFU_DATA_BUF_SIZE 500 * SZ_1K /* File transfer chunk size */
+#define CONFIG_SYS_DFU_MAX_FILE_SIZE 4 * SZ_1M   /* Maximum size for a single file.  Currently zImage (~2.5M) */
+#endif
+
+#define CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG
+
+#define BOOTENV_DEV_LEGACY_MMC(devtypeu, devtypel, instance) \
+	"bootcmd_" #devtypel #instance "=" \
+	"setenv mmcdev " #instance"; "\
+	"setenv bootpart " #instance":2 ; "\
+	"run mmcboot\0"
+
+#define BOOTENV_DEV_NAME_LEGACY_MMC(devtypeu, devtypel, instance) \
+	#devtypel #instance " "
+
+#define BOOT_TARGET_DEVICES(func) \
+	func(MMC, mmc, 0) \
+	func(LEGACY_MMC, legacy_mmc, 0) \
+	func(MMC, mmc, 1) \
+	func(LEGACY_MMC, legacy_mmc, 1) \
+	func(PXE, pxe, na) \
+	func(DHCP, dhcp, na)
+
+#define CONFIG_BOOTCOMMAND \
+	"run findfdt; " \
+	"run init_console; " \
+	"run envboot; " \
+	"run distro_bootcmd"
+
+#include <config_distro_bootcmd.h>
+
+#ifndef CONFIG_SPL_BUILD
+#define CONFIG_EXTRA_ENV_SETTINGS \
+	DEFAULT_LINUX_BOOT_ENV \
+	DEFAULT_MMC_TI_ARGS \
+	"boot_fdt=try\0" \
+	"bootpart=0:2\0" \
+	"bootdir=/boot\0" \
+	"bootfile=zImage\0" \
+	"fdtfile=pumpkin.dtb\0" \
+	"console=ttyS0,115200n8\0" \
+	"partitions=" \
+		"uuid_disk=${uuid_gpt_disk};" \
+		"name=rootfs,start=2MiB,size=-,uuid=${uuid_gpt_rootfs}\0" \
+	"optargs=\0" \
+	"loadimage=load mmc ${bootpart} ${loadaddr} ${bootdir}/${bootfile}\0" \
+	"loadfdt=load mmc ${bootpart} ${fdtaddr} ${bootdir}/${fdtfile}\0" \
+	"mmcloados=run args_mmc; " \
+		"if test ${boot_fdt} = yes || test ${boot_fdt} = try; then " \
+			"if run loadfdt; then " \
+				"bootz ${loadaddr} - ${fdtaddr}; " \
+			"else " \
+				"if test ${boot_fdt} = try; then " \
+					"bootz; " \
+				"else " \
+					"echo WARN: Cannot load the DT; " \
+				"fi; " \
+			"fi; " \
+		"else " \
+			"bootz; " \
+		"fi;\0" \
+	"mmcboot=mmc dev ${mmcdev}; " \
+		"if mmc rescan; then " \
+			"echo SD/MMC found on device ${mmcdev};" \
+			"run envboot; " \
+			"if run loadimage; then " \
+				"run mmcloados;" \
+			"fi;" \
+		"fi;\0" \
+	"init_console=" \
+		"if test $board_name = A335_ICE; then "\
+			"setenv console ttyO3,115200n8;" \
+		"else " \
+			"setenv console ttyO0,115200n8;" \
+		"fi;\0" \
+	NETARGS \
+	DFUARGS \
+	BOOTENV
+#endif
+
+/* UART (NS16550) Configurations */
+#define CONFIG_SYS_NS16550_COM1		0x44e09000	/* UART0 */
+#define CONFIG_SYS_NS16550_COM2		0x48022000	/* UART1 */
+#define CONFIG_SYS_NS16550_COM3		0x48024000	/* UART2 */
+#define CONFIG_SYS_NS16550_COM4		0x481a6000	/* UART3 */
+#define CONFIG_SYS_NS16550_COM5		0x481a8000	/* UART4 */
+#define CONFIG_SYS_NS16550_COM6		0x481aa000	/* UART5 */
+#define CONFIG_BAUDRATE			115200
+
+/* EEPROM Support */
+#define CONFIG_CMD_EEPROM
+#define CONFIG_ENV_EEPROM_IS_ON_I2C
+#define CONFIG_SYS_I2C_EEPROM_ADDR	0x50	/* Main EEPROM */
+#define CONFIG_SYS_I2C_EEPROM_ADDR_LEN	2
+
+/* PMIC support */
+#define CONFIG_POWER_TPS65217
+
+/* SPL */
+/* Bootcount using the RTC block */
+#define CONFIG_BOOTCOUNT_LIMIT
+#define CONFIG_BOOTCOUNT_AM33XX
+#define CONFIG_SYS_BOOTCOUNT_BE
+
+/* USB gadget RNDIS */
+
+#define CONFIG_SPL_LDSCRIPT		"$(CPUDIR)/am33xx/u-boot-spl.lds"
+
+/*
+ * USB configuration.  We enable MUSB support, both for host and for
+ * gadget.  We set USB0 as peripheral and USB1 as host, based on the
+ * board schematic and physical port wired to each.  Then for host we
+ * add mass storage support and for gadget we add both RNDIS ethernet
+ * and DFU.
+ */
+#define CONFIG_USB_MUSB_DSPS
+#define CONFIG_ARCH_MISC_INIT
+#define CONFIG_USB_MUSB_PIO_ONLY
+#define CONFIG_USB_MUSB_DISABLE_BULK_COMBINE_SPLIT
+#define CONFIG_AM335X_USB0
+#define CONFIG_AM335X_USB0_MODE	MUSB_PERIPHERAL
+#define CONFIG_AM335X_USB1
+#define CONFIG_AM335X_USB1_MODE MUSB_HOST
+
+#ifndef CONFIG_SPL_USBETH_SUPPORT
+/* Fastboot */
+#define CONFIG_USB_FUNCTION_FASTBOOT
+#define CONFIG_CMD_FASTBOOT
+#define CONFIG_ANDROID_BOOT_IMAGE
+#define CONFIG_FASTBOOT_BUF_ADDR	CONFIG_SYS_LOAD_ADDR
+#define CONFIG_FASTBOOT_BUF_SIZE	0x07000000
+
+/* To support eMMC booting */
+#define CONFIG_STORAGE_EMMC
+#define CONFIG_FASTBOOT_FLASH_MMC_DEV   1
+#endif
+
+#ifdef CONFIG_USB_MUSB_GADGET
+/* Removing USB gadget and can be enabled adter adding support usb DM */
+#ifndef CONFIG_DM_ETH
+#define CONFIG_USB_ETHER
+#define CONFIG_USB_ETH_RNDIS
+#define CONFIG_USBNET_HOST_ADDR	"de:ad:be:af:00:00"
+#endif /* CONFIG_DM_ETH */
+#endif /* CONFIG_USB_MUSB_GADGET */
+
+/*
+ * Disable MMC DM for SPL build and can be re-enabled after adding
+ * DM support in SPL
+ */
+#ifdef CONFIG_SPL_BUILD
+#undef CONFIG_DM_MMC
+#undef CONFIG_TIMER
+#endif
+
+#if defined(CONFIG_SPL_BUILD) && defined(CONFIG_SPL_USBETH_SUPPORT)
+/* Remove other SPL modes. */
+#define CONFIG_ENV_IS_NOWHERE
+#undef CONFIG_ENV_IS_IN_NAND
+/* disable host part of MUSB in SPL */
+/* disable EFI partitions and partition UUID support */
+#undef CONFIG_PARTITION_UUIDS
+#undef CONFIG_EFI_PARTITION
+#endif
+
+/* USB Device Firmware Update support */
+#ifndef CONFIG_SPL_BUILD
+#define DFU_ALT_INFO_MMC \
+	"dfu_alt_info_mmc=" \
+	"boot part 0 1;" \
+	"rootfs part 0 2;" \
+	"MLO fat 0 1;" \
+	"MLO.raw raw 0x100 0x100;" \
+	"u-boot.img.raw raw 0x300 0x400;" \
+	"spl-os-args.raw raw 0x80 0x80;" \
+	"spl-os-image.raw raw 0x900 0x2000;" \
+	"spl-os-args fat 0 1;" \
+	"spl-os-image fat 0 1;" \
+	"u-boot.img fat 0 1;" \
+	"uEnv.txt fat 0 1\0"
+#define DFUARGS \
+	"dfu_alt_info_emmc=rawemmc raw 0 3751936\0" \
+	DFU_ALT_INFO_MMC
+#endif
+
+if defined(CONFIG_EMMC_BOOT)
+#define CONFIG_ENV_IS_IN_MMC
+#define CONFIG_SYS_MMC_ENV_DEV		1
+#define CONFIG_SYS_MMC_ENV_PART		2
+#define CONFIG_ENV_OFFSET		0x0
+#define CONFIG_ENV_OFFSET_REDUND	(CONFIG_ENV_OFFSET + CONFIG_ENV_SIZE)
+#define CONFIG_SYS_REDUNDAND_ENVIRONMENT
+#elif defined(CONFIG_ENV_IS_IN_NAND)
+#define CONFIG_ENV_OFFSET		0x001c0000
+#define CONFIG_ENV_OFFSET_REDUND	0x001e0000
+#define CONFIG_SYS_ENV_SECT_SIZE	CONFIG_SYS_NAND_BLOCK_SIZE
+#elif !defined(CONFIG_ENV_IS_NOWHERE)
+/* Not NAND, SPI, NOR or eMMC env, so put ENV in a file on FAT */
+#define CONFIG_ENV_IS_IN_FAT
+#define FAT_ENV_INTERFACE		"mmc"
+#define FAT_ENV_DEVICE_AND_PART		"0:1"
+#define FAT_ENV_FILE			"uboot.env"
+#endif
+
+/* SPI flash. */
+#define CONFIG_SF_DEFAULT_SPEED		24000000
+
+/* Network. */
+#define CONFIG_PHY_GIGE
+#define CONFIG_PHYLIB
+#define CONFIG_PHY_SMSC
+
+#ifdef CONFIG_DRIVER_TI_CPSW
+#define CONFIG_CLOCK_SYNTHESIZER
+#define CLK_SYNTHESIZER_I2C_ADDR 0x65
+#endif
+
+#endif	/* ! __CONFIG_AM335X_EVM_H */

--- a/include/configs/pumpkin-mbm2.h
+++ b/include/configs/pumpkin-mbm2.h
@@ -20,6 +20,11 @@
 
 /* Undo things we don't want to include from the base Beaglebone Black configuration */
 #undef CONFIG_SYS_LDSCRIPT /* For NOR flash, which we (and the BBB) don't support */
+#undef CONFIG_BOOTCOMMAND
+
+#define CONFIG_BOOTCOMMAND \
+	"fdtfile=pumpkin-mbm2.dtb; " \
+	"run distro_bootcmd"
 
 /* File updates */
 #ifdef CONFIG_UPDATE_KUBOS

--- a/include/configs/pumpkin-mbm2.h
+++ b/include/configs/pumpkin-mbm2.h
@@ -49,7 +49,7 @@
 /* U-boot env file in user data partition */
 #define CONFIG_ENV_IS_IN_EXT4    1
 #define EXT4_ENV_INTERFACE       "mmc"
-#define EXT4_ENV_DEVICE_AND_PART "0:3" /* TODO */
+#define EXT4_ENV_DEVICE_AND_PART "1:3"
 #define EXT4_ENV_FILE            "/system/etc/uboot.env"
 #define CONFIG_ENV_SIZE         10 * 1024 /* Assume sector size of 1024 */
 #endif
@@ -59,15 +59,15 @@
 /* File updates */
 #ifdef CONFIG_UPDATE_KUBOS
 #define CONFIG_SYS_DFU_DATA_BUF_SIZE 500 * SZ_1K /* File transfer chunk size */
-#define CONFIG_SYS_DFU_MAX_FILE_SIZE 4 * SZ_1M   /* Maximum size for a single file.  Currently zImage (~2.5M) */
+#define CONFIG_SYS_DFU_MAX_FILE_SIZE 4 * SZ_1M   /* Maximum size for a single file.  Currently kernel (~2.5M) */
 
 /* DFU Configuration TODO*/
 #define DFU_ALT_INFO_MMC \
 	"dfu_alt_info_mmc=" 		\
-	"kernel fat 0 1;" 		\
-	"rootfs part 0 2; " \
-	"uboot fat 0 1;" \
-	"dtb fat 0 1" \
+	"kernel fat 1 1;" 		\
+	"rootfs part 1 2; " \
+	"uboot fat 1 1;" \
+	"dtb fat 1 1" \
 	"\0"
 
 #define DFU_ALT_INFO_NOR ""
@@ -78,8 +78,8 @@
 
 /* TODO: The mmc device will change when we start booting from emmc rather than directly from the sd card */
 #define CONFIG_BOOTCOMMAND \
-	"fatload mmc 0:1 ${fdtaddr} /pumpkin-mbm2.dtb; " \
-	"fatload mmc 0:1 ${loadaddr} /kernel; " \
+	"fatload mmc 1:1 ${fdtaddr} /pumpkin-mbm2.dtb; " \
+	"fatload mmc 1:1 ${loadaddr} /kernel; " \
 	"bootm ${loadaddr} - ${fdtaddr}"
 
 #define CONFIG_BOOTARGS \

--- a/include/configs/pumpkin-mbm2.h
+++ b/include/configs/pumpkin-mbm2.h
@@ -23,8 +23,38 @@
 #undef CONFIG_BOOTCOMMAND
 
 #define CONFIG_BOOTCOMMAND \
-	"fdtfile=pumpkin-mbm2.dtb; " \
 	"run distro_bootcmd"
+
+#undef CONFIG_EXTRA_ENV_SETTINGS
+
+#define CONFIG_EXTRA_ENV_SETTINGS \
+	DEFAULT_LINUX_BOOT_ENV \
+	DEFAULT_MMC_TI_ARGS \
+	"bootpart=0:2\0" \
+	"bootdir=/boot\0" \
+	"bootfile=zImage\0" \
+	"fdtfile=pumpkin-mbm2.dtb\0" \
+	"console=ttyS0,115200n8\0" \
+	"partitions=" \
+		"uuid_disk=${uuid_gpt_disk};" \
+		"name=rootfs,start=2MiB,size=-,uuid=${uuid_gpt_rootfs}\0" \
+	"optargs=\0" \
+	"loadimage=load mmc ${bootpart} ${loadaddr} ${bootdir}/${bootfile}\0" \
+	"loadfdt=load mmc ${bootpart} ${fdtaddr} ${bootdir}/${fdtfile}\0" \
+	"mmcloados=run args_mmc; run loadfdt; " \
+				"bootz ${loadaddr} - ${fdtaddr}\0"
+	"mmcboot=mmc dev ${mmcdev}; " \
+		"if mmc rescan; then " \
+			"echo SD/MMC found on device ${mmcdev};" \
+			"run envboot; " \
+			"if run loadimage; then " \
+				"run mmcloados;" \
+			"fi;" \
+		"fi;\0" \
+	NETARGS \
+	DFUARGS \
+	BOOTENV
+#endif
 
 /* File updates */
 #ifdef CONFIG_UPDATE_KUBOS

--- a/include/configs/pumpkin-mbm2.h
+++ b/include/configs/pumpkin-mbm2.h
@@ -1,265 +1,71 @@
 /*
- * pumpkin-mbm2.h
- *
- * Copyright (C) 2011 Texas Instruments Incorporated - http://www.ti.com/
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License as
- * published by the Free Software Foundation version 2.
- *
- * This program is distributed "as is" WITHOUT ANY WARRANTY of any
- * kind, whether express or implied; without even the implied warranty
- * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- */
+* Copyright (C) 2017 Kubos Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 
 #pragma once
 
-#include <configs/ti_am335x_common.h>
-
-#ifndef CONFIG_SPL_BUILD
-# define CONFIG_TIMESTAMP
-# define CONFIG_LZO
-#endif
-
-#define CONFIG_SYS_BOOTM_LEN		(16 << 20)
-
-#define MACH_TYPE_TIAM335EVM		3589	/* Until the next sync */
-#define CONFIG_MACH_TYPE		MACH_TYPE_TIAM335EVM
-#define CONFIG_BOARD_LATE_INIT
-
-/* Clock Defines */
-#define V_OSCK				24000000  /* Clock output from T2 */
-#define V_SCLK				(V_OSCK)
-
-/* Always 128 KiB env size */
-#define CONFIG_ENV_SIZE			(128 << 10)
-
-/* Enhance our eMMC support / experience. */
-#define CONFIG_CMD_GPT
-#define CONFIG_EFI_PARTITION
+#include <configs/am333x_evm.h>
 
 /* File updates */
 #ifdef CONFIG_UPDATE_KUBOS
 #define CONFIG_SYS_DFU_DATA_BUF_SIZE 500 * SZ_1K /* File transfer chunk size */
 #define CONFIG_SYS_DFU_MAX_FILE_SIZE 4 * SZ_1M   /* Maximum size for a single file.  Currently zImage (~2.5M) */
+#endif
+
+/* Update Definitions */
+#ifdef CONFIG_UPDATE_KUBOS
 
 #define KUBOS_CURR_VERSION "kubos_curr_version"
 #define KUBOS_PREV_VERSION "kubos_prev_version"
 #define KUBOS_CURR_TRIED   "kubos_curr_tried"
 #define KUBOS_BASE         "kpack-base.itb"
 #define KUBOS_UPDATE_FILE  "kubos_updatefile"
+
 #endif
 
-#define CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG
+#ifdef TEMP_FAKE_DEFINE
+#ifdef CONFIG_UPDATE_KUBOS
 
-#define BOOTENV_DEV_LEGACY_MMC(devtypeu, devtypel, instance) \
-	"bootcmd_" #devtypel #instance "=" \
-	"setenv mmcdev " #instance"; "\
-	"setenv bootpart " #instance":2 ; "\
-	"run mmcboot\0"
-
-#define BOOTENV_DEV_NAME_LEGACY_MMC(devtypeu, devtypel, instance) \
-	#devtypel #instance " "
-
-#define BOOT_TARGET_DEVICES(func) \
-	func(MMC, mmc, 0) \
-	func(LEGACY_MMC, legacy_mmc, 0) \
-	func(MMC, mmc, 1) \
-	func(LEGACY_MMC, legacy_mmc, 1) \
-	func(PXE, pxe, na) \
-	func(DHCP, dhcp, na)
-
-#define CONFIG_BOOTCOMMAND \
-	"run findfdt; " \
-	"run init_console; " \
-	"run envboot; " \
-	"run distro_bootcmd"
-
-#include <config_distro_bootcmd.h>
-
-#ifndef CONFIG_SPL_BUILD
-#define CONFIG_EXTRA_ENV_SETTINGS \
-	DEFAULT_LINUX_BOOT_ENV \
-	DEFAULT_MMC_TI_ARGS \
-	"boot_fdt=try\0" \
-	"bootpart=0:2\0" \
-	"bootdir=/boot\0" \
-	"bootfile=zImage\0" \
-	"fdtfile=pumpkin.dtb\0" \
-	"console=ttyS0,115200n8\0" \
-	"partitions=" \
-		"uuid_disk=${uuid_gpt_disk};" \
-		"name=rootfs,start=2MiB,size=-,uuid=${uuid_gpt_rootfs}\0" \
-	"optargs=\0" \
-	"loadimage=load mmc ${bootpart} ${loadaddr} ${bootdir}/${bootfile}\0" \
-	"loadfdt=load mmc ${bootpart} ${fdtaddr} ${bootdir}/${fdtfile}\0" \
-	"mmcloados=run args_mmc; " \
-		"if test ${boot_fdt} = yes || test ${boot_fdt} = try; then " \
-			"if run loadfdt; then " \
-				"bootz ${loadaddr} - ${fdtaddr}; " \
-			"else " \
-				"if test ${boot_fdt} = try; then " \
-					"bootz; " \
-				"else " \
-					"echo WARN: Cannot load the DT; " \
-				"fi; " \
-			"fi; " \
-		"else " \
-			"bootz; " \
-		"fi;\0" \
-	"mmcboot=mmc dev ${mmcdev}; " \
-		"if mmc rescan; then " \
-			"echo SD/MMC found on device ${mmcdev};" \
-			"run envboot; " \
-			"if run loadimage; then " \
-				"run mmcloados;" \
-			"fi;" \
-		"fi;\0" \
-	"init_console=" \
-		"if test $board_name = A335_ICE; then "\
-			"setenv console ttyO3,115200n8;" \
-		"else " \
-			"setenv console ttyO0,115200n8;" \
-		"fi;\0" \
-	NETARGS \
-	DFUARGS \
-	BOOTENV
-#endif
-
-/* UART (NS16550) Configurations */
-#define CONFIG_SYS_NS16550_COM1		0x44e09000	/* UART0 */
-#define CONFIG_SYS_NS16550_COM2		0x48022000	/* UART1 */
-#define CONFIG_SYS_NS16550_COM3		0x48024000	/* UART2 */
-#define CONFIG_SYS_NS16550_COM4		0x481a6000	/* UART3 */
-#define CONFIG_SYS_NS16550_COM5		0x481a8000	/* UART4 */
-#define CONFIG_SYS_NS16550_COM6		0x481aa000	/* UART5 */
-#define CONFIG_BAUDRATE			115200
-
-/* EEPROM Support */
-#define CONFIG_CMD_EEPROM
-#define CONFIG_ENV_EEPROM_IS_ON_I2C
-#define CONFIG_SYS_I2C_EEPROM_ADDR	0x50	/* Main EEPROM */
-#define CONFIG_SYS_I2C_EEPROM_ADDR_LEN	2
-
-/* PMIC support */
-#define CONFIG_POWER_TPS65217
-
-/* SPL */
-/* Bootcount using the RTC block */
-#define CONFIG_BOOTCOUNT_LIMIT
-#define CONFIG_BOOTCOUNT_AM33XX
-#define CONFIG_SYS_BOOTCOUNT_BE
-
-/* USB gadget RNDIS */
-
-#define CONFIG_SPL_LDSCRIPT		"$(CPUDIR)/am33xx/u-boot-spl.lds"
-
-/*
- * USB configuration.  We enable MUSB support, both for host and for
- * gadget.  We set USB0 as peripheral and USB1 as host, based on the
- * board schematic and physical port wired to each.  Then for host we
- * add mass storage support and for gadget we add both RNDIS ethernet
- * and DFU.
- */
-#define CONFIG_USB_MUSB_DSPS
-#define CONFIG_ARCH_MISC_INIT
-#define CONFIG_USB_MUSB_PIO_ONLY
-#define CONFIG_USB_MUSB_DISABLE_BULK_COMBINE_SPLIT
-#define CONFIG_AM335X_USB0
-#define CONFIG_AM335X_USB0_MODE	MUSB_PERIPHERAL
-#define CONFIG_AM335X_USB1
-#define CONFIG_AM335X_USB1_MODE MUSB_HOST
-
-#ifndef CONFIG_SPL_USBETH_SUPPORT
-/* Fastboot */
-#define CONFIG_USB_FUNCTION_FASTBOOT
-#define CONFIG_CMD_FASTBOOT
-#define CONFIG_ANDROID_BOOT_IMAGE
-#define CONFIG_FASTBOOT_BUF_ADDR	CONFIG_SYS_LOAD_ADDR
-#define CONFIG_FASTBOOT_BUF_SIZE	0x07000000
-
-/* To support eMMC booting */
-#define CONFIG_STORAGE_EMMC
-#define CONFIG_FASTBOOT_FLASH_MMC_DEV   1
-#endif
-
-#ifdef CONFIG_USB_MUSB_GADGET
-/* Removing USB gadget and can be enabled adter adding support usb DM */
-#ifndef CONFIG_DM_ETH
-#define CONFIG_USB_ETHER
-#define CONFIG_USB_ETH_RNDIS
-#define CONFIG_USBNET_HOST_ADDR	"de:ad:be:af:00:00"
-#endif /* CONFIG_DM_ETH */
-#endif /* CONFIG_USB_MUSB_GADGET */
-
-/*
- * Disable MMC DM for SPL build and can be re-enabled after adding
- * DM support in SPL
- */
-#ifdef CONFIG_SPL_BUILD
-#undef CONFIG_DM_MMC
-#undef CONFIG_TIMER
-#endif
-
-#if defined(CONFIG_SPL_BUILD) && defined(CONFIG_SPL_USBETH_SUPPORT)
-/* Remove other SPL modes. */
-#define CONFIG_ENV_IS_NOWHERE
-#undef CONFIG_ENV_IS_IN_NAND
-/* disable host part of MUSB in SPL */
-/* disable EFI partitions and partition UUID support */
-#undef CONFIG_PARTITION_UUIDS
-#undef CONFIG_EFI_PARTITION
-#endif
-
-/* USB Device Firmware Update support */
-#ifndef CONFIG_SPL_BUILD
+/* DFU Configuration */
 #define DFU_ALT_INFO_MMC \
-	"dfu_alt_info_mmc=" \
-	"boot part 0 1;" \
-	"rootfs part 0 2;" \
-	"MLO fat 0 1;" \
-	"MLO.raw raw 0x100 0x100;" \
-	"u-boot.img.raw raw 0x300 0x400;" \
-	"spl-os-args.raw raw 0x80 0x80;" \
-	"spl-os-image.raw raw 0x900 0x2000;" \
-	"spl-os-args fat 0 1;" \
-	"spl-os-image fat 0 1;" \
-	"u-boot.img fat 0 1;" \
-	"uEnv.txt fat 0 1\0"
-#define DFUARGS \
-	"dfu_alt_info_emmc=rawemmc raw 0 3751936\0" \
-	DFU_ALT_INFO_MMC
-#endif
+	"dfu_alt_info_mmc=" 		\
+	"kernel fat 0 5;" 		\
+	"rootfs part 0 6\0"
 
-#if defined(CONFIG_EMMC_BOOT)
-#define CONFIG_ENV_IS_IN_MMC
-#define CONFIG_SYS_MMC_ENV_DEV		1
-#define CONFIG_SYS_MMC_ENV_PART		2
-#define CONFIG_ENV_OFFSET		0x0
-#define CONFIG_ENV_OFFSET_REDUND	(CONFIG_ENV_OFFSET + CONFIG_ENV_SIZE)
-#define CONFIG_SYS_REDUNDAND_ENVIRONMENT
-#elif defined(CONFIG_ENV_IS_IN_NAND)
-#define CONFIG_ENV_OFFSET		0x001c0000
-#define CONFIG_ENV_OFFSET_REDUND	0x001e0000
-#define CONFIG_SYS_ENV_SECT_SIZE	CONFIG_SYS_NAND_BLOCK_SIZE
-#elif !defined(CONFIG_ENV_IS_NOWHERE)
-/* Not NAND, SPI, NOR or eMMC env, so put ENV in a file on FAT */
-#define CONFIG_ENV_IS_IN_FAT
-#define FAT_ENV_INTERFACE		"mmc"
-#define FAT_ENV_DEVICE_AND_PART		"0:1"
-#define FAT_ENV_FILE			"uboot.env"
-#endif
+#define DFU_ALT_INFO_NOR \
+	"dfu_alt_info_nor="		    \
+	"uboot raw 0xA000 0x56000;" \
+	"dtb raw 0x70000 0x10000" \
+	"\0"
 
-/* SPI flash. */
-#define CONFIG_SF_DEFAULT_SPEED		24000000
+#define CONFIG_EXTRA_ENV_SETTINGS \
+	"altbootcmd=setenv recovery_available 0; setenv bootcmd; saveenv\0" \
+	"recovery_available=1\0" \
+    "bootlimit=3\0" \
+	KUBOS_CURR_VERSION "=" KUBOS_BASE "\0" \
+	KUBOS_PREV_VERSION "=" KUBOS_BASE "\0" \
+	KUBOS_CURR_TRIED "=0\0" \
+	DFU_ALT_INFO_MMC \
+	DFU_ALT_INFO_NOR
 
-/* Network. */
-#define CONFIG_PHY_GIGE
-#define CONFIG_PHYLIB
-#define CONFIG_PHY_SMSC
+#else
 
-#ifdef CONFIG_DRIVER_TI_CPSW
-#define CONFIG_CLOCK_SYNTHESIZER
-#define CLK_SYNTHESIZER_I2C_ADDR 0x65
-#endif
+#define CONFIG_EXTRA_ENV_SETTINGS \
+	"altbootcmd=setenv recovery_available 0; setenv bootcmd; saveenv\0" \
+	"recovery_available=1\0" \
+    "bootlimit=1\0" \
+
+#endif /* CONFIG_UPDATE_KUBOS */
+#endif /* Placeholder */

--- a/include/configs/pumpkin-mbm2.h
+++ b/include/configs/pumpkin-mbm2.h
@@ -41,9 +41,14 @@
 
 /* File updates */
 #ifdef CONFIG_UPDATE_KUBOS
-#define CONFIG_USB_FUNCTION_DFU
 #define CONFIG_SYS_DFU_DATA_BUF_SIZE 500 * SZ_1K /* File transfer chunk size */
 #define CONFIG_SYS_DFU_MAX_FILE_SIZE 4 * SZ_1M   /* Maximum size for a single file.  Currently zImage (~2.5M) */
+
+#define KUBOS_CURR_VERSION "kubos_curr_version"
+#define KUBOS_PREV_VERSION "kubos_prev_version"
+#define KUBOS_CURR_TRIED   "kubos_curr_tried"
+#define KUBOS_BASE         "kpack-base.itb"
+#define KUBOS_UPDATE_FILE  "kubos_updatefile"
 #endif
 
 #define CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG
@@ -227,7 +232,7 @@
 	DFU_ALT_INFO_MMC
 #endif
 
-if defined(CONFIG_EMMC_BOOT)
+#if defined(CONFIG_EMMC_BOOT)
 #define CONFIG_ENV_IS_IN_MMC
 #define CONFIG_SYS_MMC_ENV_DEV		1
 #define CONFIG_SYS_MMC_ENV_PART		2
@@ -258,5 +263,3 @@ if defined(CONFIG_EMMC_BOOT)
 #define CONFIG_CLOCK_SYNTHESIZER
 #define CLK_SYNTHESIZER_I2C_ADDR 0x65
 #endif
-
-#endif	/* ! __CONFIG_AM335X_EVM_H */

--- a/include/configs/pumpkin-mbm2.h
+++ b/include/configs/pumpkin-mbm2.h
@@ -18,6 +18,9 @@
 
 #include "am335x_evm.h"
 
+/* Undo things we don't want to include from the base Beaglebone Black configuration */
+#undef CONFIG_SYS_LDSCRIPT /* For NOR flash, which we (and the BBB) don't support */
+
 /* File updates */
 #ifdef CONFIG_UPDATE_KUBOS
 #define CONFIG_SYS_DFU_DATA_BUF_SIZE 500 * SZ_1K /* File transfer chunk size */

--- a/include/configs/pumpkin-mbm2.h
+++ b/include/configs/pumpkin-mbm2.h
@@ -12,6 +12,15 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
+*
+* pumpkin-mbm2.h
+*
+* Configuration file for the Pumpkin Motherboard Module 2, using a Beaglebone Black
+* as the OBC.
+*
+* Note: By default, KubOS Linux will be booted from the eMMC storage. This is defined
+* to the system as the SECOND MMC device. The microSD card is defined as the FIRST MMC
+* device.
 */
 
 #pragma once
@@ -32,28 +41,19 @@
 #undef CONFIG_BOOTCOUNT_AM33XX
 /* End of undefs */
 
+/* If we're compiling for the SPL, we don't have an env area */
 #if defined(CONFIG_SPL_BUILD) && defined(CONFIG_SPL_USBETH_SUPPORT)
-/* Remove other SPL modes. */
 #define CONFIG_ENV_IS_NOWHERE
-#undef CONFIG_ENV_IS_IN_NAND
-/* disable host part of MUSB in SPL */
-/* disable EFI partitions and partition UUID support */
-#undef CONFIG_PARTITION_UUIDS
-#undef CONFIG_EFI_PARTITION
 #else
-
-/* EXT4 */
+/* Otherwise, it's in an ext4 partition */
 #ifdef CONFIG_CMD_EXT4
 #define CONFIG_EXT4_WRITE
-
-/* U-boot env file in user data partition */
 #define CONFIG_ENV_IS_IN_EXT4    1
 #define EXT4_ENV_INTERFACE       "mmc"
 #define EXT4_ENV_DEVICE_AND_PART "1:3"
 #define EXT4_ENV_FILE            "/system/etc/uboot.env"
 #define CONFIG_ENV_SIZE         10 * 1024 /* Assume sector size of 1024 */
 #endif
-
 #endif /* CONFIG_SPL_BUILD */
 
 /* File updates */
@@ -61,7 +61,10 @@
 #define CONFIG_SYS_DFU_DATA_BUF_SIZE 500 * SZ_1K /* File transfer chunk size */
 #define CONFIG_SYS_DFU_MAX_FILE_SIZE 4 * SZ_1M   /* Maximum size for a single file.  Currently kernel (~2.5M) */
 
-/* DFU Configuration TODO*/
+#define KUBOS_UPGRADE_DEVICE 0
+#define KUBOS_UPGRADE_PART   1
+
+/* DFU Configuration */
 #define DFU_ALT_INFO_MMC \
 	"dfu_alt_info_mmc=" 		\
 	"kernel fat 1 1;" 		\
@@ -76,7 +79,7 @@
 #define DFU_ALT_INFO_NOR ""
 #endif /* CONFIG_UPDATE_KUBOS */
 
-/* TODO: The mmc device will change when we start booting from emmc rather than directly from the sd card */
+/* Boot from eMMC */
 #define CONFIG_BOOTCOMMAND \
 	"fatload mmc 1:1 ${fdtaddr} /pumpkin-mbm2.dtb; " \
 	"fatload mmc 1:1 ${loadaddr} /kernel; " \

--- a/include/configs/pumpkin-mbm2.h
+++ b/include/configs/pumpkin-mbm2.h
@@ -26,6 +26,7 @@
 #undef CONFIG_ENV_IS_IN_MMC
 #undef CONFIG_ENV_IS_IN_FAT
 #undef CONFIG_ENV_IS_NOWHERE
+#undef CONFIG_ENV_SIZE
 #undef DFU_ALT_INFO_MMC
 #undef DFU_ALT_INFO_NOR
 /* End of undefs */
@@ -40,6 +41,7 @@
 #undef CONFIG_EFI_PARTITION
 #else
 
+#if 0 /* temporary */
 /* EXT4 */
 #ifdef CONFIG_CMD_EXT4
 #define CONFIG_EXT4_WRITE
@@ -49,8 +51,15 @@
 #define EXT4_ENV_INTERFACE       "mmc"
 #define EXT4_ENV_DEVICE_AND_PART "0:3" /* TODO */
 #define EXT4_ENV_FILE            "/system/etc/uboot.env"
-#define CONFIG_ENV_SIZE         1 * 1024 //Assume sector size of 1024
+#define CONFIG_ENV_SIZE         1 * 1024 /* Assume sector size of 1024 */
 #endif
+#else
+
+#define CONFIG_ENV_IS_IN_FAT
+#define FAT_ENV_INTERFACE		"mmc"
+#define FAT_ENV_DEVICE_AND_PART		"0:1"
+#define FAT_ENV_FILE			"uboot.env"
+#endif /* temporary */
 #endif /* CONFIG_SPL_BUILD */
 
 /* File updates */
@@ -62,7 +71,7 @@
 #define DFU_ALT_INFO_MMC \
 	"dfu_alt_info_mmc=" 		\
 	"kernel fat 0 1;" 		\
-	"rootfs part 0 2\0"
+	"rootfs part 0 2; " \
 	"uboot fat 0 1;" \
 	"dtb fat 0 1" \
 	"\0"
@@ -81,7 +90,7 @@
 
 #define CONFIG_BOOTARGS \
 	"console=ttyS0,115200 "				\
-	"root=/dev/mmcblk0p2 rootwait"
+	"root=/dev/mmcblk0p2 ext4 rootwait"
 
 #ifndef CONFIG_SPL_BUILD
 #define CONFIG_EXTRA_ENV_SETTINGS \


### PR DESCRIPTION
This PR adds the new pumpkin board to U-Boot. It's getting merged into a development branch because the Kubos upgrade/recovery support isn't fully in place yet; there are some initial/temporary definitions that will get hardened in the next PR but will break things if they're used right now.

Notable changes:
- board/kubos/pumpkin-mbm2/Makefile: right now this is a direct inheritance of the Beaglebone Black files (which are actually the AM335x EVM board files). Once the pumpkin watchdog is integrated, this will likely get changed.
- include/configs/kubos-common.h: There are a bunch of options for kubos upgrade that will be common for all the boards, so I created a common file to house them.
- include/configs/at91sam9g20isis.h: Cleaned up to use the new `kubos-common.h` file