### PR TITLE
Kubos upgrade/recovery for pumpkin

### DIFF
--- a/board/kubos/pumpkin-mbm2/Makefile
+++ b/board/kubos/pumpkin-mbm2/Makefile
@@ -21,4 +21,6 @@ obj-y	+= ../../ti/am335x/board.o
 obj-y	+= ../../ti/am335x/mux.o
 obj-y	+= ../../ti/common/board_detect.o
 
+obj-y   += led.o
+
 

--- a/board/kubos/pumpkin-mbm2/led.c
+++ b/board/kubos/pumpkin-mbm2/led.c
@@ -21,13 +21,11 @@
 
 void coloured_LED_init(void)
 {
-	/* Mark pins for output */
-	gpio_direction_output(CONFIG_LED1, 1);
-	gpio_direction_output(CONFIG_LED2, 1);
-	gpio_direction_output(CONFIG_LED3, 1);
+	gpio_direction_output(CONFIG_RED_LED, 1);
+	gpio_direction_output(CONFIG_GREEN_LED, 1);
+	gpio_direction_output(CONFIG_YELLOW_LED, 1);
 
-	/* Turn them on */
-	gpio_set_value(CONFIG_LED1, 1);
-	gpio_set_value(CONFIG_LED2, 1);
-	gpio_set_value(CONFIG_LED3, 1);
+	gpio_set_value(CONFIG_RED_LED, 1);
+	gpio_set_value(CONFIG_GREEN_LED, 1);
+	gpio_set_value(CONFIG_YELLOW_LED, 1);
 }

--- a/board/kubos/pumpkin-mbm2/led.c
+++ b/board/kubos/pumpkin-mbm2/led.c
@@ -1,0 +1,33 @@
+/*
+* Copyright (C) 2017 Kubos Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
+
+#include <common.h>
+#include <asm/io.h>
+#include <asm/arch/gpio.h>
+
+void coloured_LED_init(void)
+{
+	/* Mark pins for output */
+	gpio_direction_output(CONFIG_LED1, 1);
+	gpio_direction_output(CONFIG_LED2, 1);
+	gpio_direction_output(CONFIG_LED3, 1);
+
+	/* Turn them on */
+	gpio_set_value(CONFIG_LED1, 1);
+	gpio_set_value(CONFIG_LED2, 1);
+	gpio_set_value(CONFIG_LED3, 1);
+}

--- a/common/update_kubos.c
+++ b/common/update_kubos.c
@@ -22,7 +22,6 @@
 #include <mmc.h>
 #include <kubos.h>
 
-#define UPGRADE_PART 7
 #define UPDATE_COUNT_ENVAR "kubos_updatecount"
 #define PART_ENVAR         "kubos_updatepart"
 #define LOAD_ENVAR         "kubos_loadaddr"
@@ -121,7 +120,7 @@ int update_kubos(bool upgrade)
 	/*
 	 * Load the SD card
 	 */
-	mmc = find_mmc_device(0);
+	mmc = find_mmc_device(KUBOS_UPGRADE_DEVICE);
 	if (!mmc)
 	{
 		printf("ERROR: Could not access SD card\n");
@@ -152,7 +151,7 @@ int update_kubos(bool upgrade)
 	}
 	else
 	{
-		part = UPGRADE_PART;
+		part = KUBOS_UPGRADE_PART;
 	}
 
 	if (part_get_info(&mmc->block_dev, part, &part_info))

--- a/common/update_kubos.c
+++ b/common/update_kubos.c
@@ -224,9 +224,12 @@ int update_kubos(bool upgrade)
 
 				setenv("dfu_alt_info", dfu_info);
 
-				char dev_num = KUBOS_UPGRADE_DEVICE;
-
-				ret = update_tftp(addr, "mmc", *dev_num);
+				/*
+				 * For right now, the "0" parameter is useless. If you add a dfu_alt_info entity
+				 * in the future which has an entity type of "raw", this might need to change
+				 * to specify a non-zero mmc device number.
+				 */
+				ret = update_tftp(addr, "mmc", "0");
 			}
 
 			if (ret)

--- a/drivers/dfu/dfu_mmc.c
+++ b/drivers/dfu/dfu_mmc.c
@@ -310,8 +310,6 @@ int dfu_fill_entity_mmc(struct dfu_entity *dfu, char *devstr, char *s)
 	const char *argv[3];
 	const char **parg = argv;
 
-	dfu->data.mmc.dev_num = simple_strtoul(devstr, NULL, 10);
-
 	for (; parg < argv + sizeof(argv) / sizeof(*argv); ++parg) {
 		*parg = strsep(&s, " ");
 		if (*parg == NULL) {
@@ -327,6 +325,17 @@ int dfu_fill_entity_mmc(struct dfu_entity *dfu, char *devstr, char *s)
 	 */
 	second_arg = simple_strtoul(argv[1], NULL, 0);
 	third_arg = simple_strtoul(argv[2], NULL, 0);
+
+	/* if it's NOT a raw write */
+	if (strcmp(entity_type, "raw")) {
+		dfu->data.mmc.dev_num = (int) second_arg;
+		dfu->data.mmc.dev = second_arg;
+		dfu->data.mmc.part = third_arg;
+	}
+	else
+	{
+		dfu->data.mmc.dev_num = simple_strtoul(devstr, NULL, 10);
+	}
 
 	mmc = find_mmc_device(dfu->data.mmc.dev_num);
 	if (mmc == NULL) {
@@ -379,12 +388,6 @@ int dfu_fill_entity_mmc(struct dfu_entity *dfu, char *devstr, char *s)
 	} else {
 		error("Memory layout (%s) not supported!\n", entity_type);
 		return -ENODEV;
-	}
-
-	/* if it's NOT a raw write */
-	if (strcmp(entity_type, "raw")) {
-		dfu->data.mmc.dev = second_arg;
-		dfu->data.mmc.part = third_arg;
 	}
 
 	dfu->dev_type = DFU_DEV_MMC;

--- a/include/configs/at91sam9g20isis.h
+++ b/include/configs/at91sam9g20isis.h
@@ -86,6 +86,9 @@
 #define CONFIG_SYS_DFU_DATA_BUF_SIZE 500 * SZ_1K /* File transfer chunk size */
 #define CONFIG_SYS_DFU_MAX_FILE_SIZE 4 * SZ_1M   /* Maximum size for a single file.  Currently zImage (~2.5M) */
 
+#define KUBOS_UPGRADE_DEVICE 0
+#define KUBOS_UPGRADE_PART   7
+
 /* DFU Configuration */
 #define DFU_ALT_INFO_MMC \
 	"dfu_alt_info_mmc=" 		\

--- a/include/configs/at91sam9g20isis.h
+++ b/include/configs/at91sam9g20isis.h
@@ -88,6 +88,7 @@
 
 #define KUBOS_UPGRADE_DEVICE 0
 #define KUBOS_UPGRADE_PART   7
+#define KUBOS_UPGRADE_STORAGE CONFIG_SYS_SDRAM_BASE + 0x200 /* Temporary SDRAM storage location */
 
 /* DFU Configuration */
 #define DFU_ALT_INFO_MMC \

--- a/include/configs/kubos-common.h
+++ b/include/configs/kubos-common.h
@@ -25,8 +25,9 @@
  * - DFU_ALT_INFO_NOR - Same as above, but for NOR flash storage
  * - CONFIG_SYS_DFU_DATA_BUF_SIZE - File transfer chunk size (for raw or file transfer. EXT4, FAT, etc)
  * - CONFIG_SYS_DFU_MAX_FILE_SIZE - Max size for a single file (partition transfer)
- * - KUBOS_UPGRADE_DEVICE - MMC device which has the upgrade partition
- * - KUBOS_UPGRADE_PART   - The partition where the upgrade files are located
+ * - KUBOS_UPGRADE_DEVICE  - MMC device which has the upgrade partition
+ * - KUBOS_UPGRADE_PART    - Partition where the upgrade files are located
+ * - KUBOS_UPGRADE_STORAGE - SDRAM address to be used for temporary storage while upgrading files
  */
 
 #pragma once

--- a/include/configs/kubos-common.h
+++ b/include/configs/kubos-common.h
@@ -25,6 +25,8 @@
  * - DFU_ALT_INFO_NOR - Same as above, but for NOR flash storage
  * - CONFIG_SYS_DFU_DATA_BUF_SIZE - File transfer chunk size (for raw or file transfer. EXT4, FAT, etc)
  * - CONFIG_SYS_DFU_MAX_FILE_SIZE - Max size for a single file (partition transfer)
+ * - KUBOS_UPGRADE_DEVICE - MMC device which has the upgrade partition
+ * - KUBOS_UPGRADE_PART   - The partition where the upgrade files are located
  */
 
 #pragma once

--- a/include/configs/pumpkin-mbm2.h
+++ b/include/configs/pumpkin-mbm2.h
@@ -81,16 +81,14 @@
 
 /* Boot from eMMC */
 #define CONFIG_BOOTCOMMAND \
-	"fatload mmc 1:1 ${fdtaddr} /pumpkin-mbm2.dtb; " \
-	"fatload mmc 1:1 ${loadaddr} /kernel; " \
+	"setenv bootargs console=ttyS0,115200 root=/dev/mmcblk${boot_dev}p2 ext4 rootwait; " \
+	"fatload mmc ${boot_dev}:1 ${fdtaddr} /pumpkin-mbm2.dtb; " \
+	"fatload mmc ${boot_dev}:1 ${loadaddr} /kernel; " \
 	"bootm ${loadaddr} - ${fdtaddr}"
-
-#define CONFIG_BOOTARGS \
-	"console=ttyS0,115200 "				\
-	"root=/dev/mmcblk1p2 ext4 rootwait"
 
 #ifndef CONFIG_SPL_BUILD
 #define CONFIG_EXTRA_ENV_SETTINGS \
+	"boot_dev=1\0" \
 	DEFAULT_LINUX_BOOT_ENV \
 	NETARGS \
 	BOOTENV \

--- a/include/configs/pumpkin-mbm2.h
+++ b/include/configs/pumpkin-mbm2.h
@@ -95,8 +95,3 @@
 	KUBOS_UPDATE_ARGS
 #endif
 
-/* Status LEDs */
-#define CONFIG_RED_LED					0x53
-#define CONFIG_GREEN_LED				0x54
-#define CONFIG_YELLOW_LED				0x55
-#define CONFIG_BLUE_LED					0x56

--- a/include/configs/pumpkin-mbm2.h
+++ b/include/configs/pumpkin-mbm2.h
@@ -95,3 +95,8 @@
 	KUBOS_UPDATE_ARGS
 #endif
 
+/* Status LEDs */
+#define CONFIG_LED1				0x53
+#define CONFIG_LED2				0x54
+#define CONFIG_LED3				0x55
+#define CONFIG_LED4				0x56

--- a/include/configs/pumpkin-mbm2.h
+++ b/include/configs/pumpkin-mbm2.h
@@ -96,7 +96,7 @@
 #endif
 
 /* Status LEDs */
-#define CONFIG_LED1				0x53
-#define CONFIG_LED2				0x54
-#define CONFIG_LED3				0x55
-#define CONFIG_LED4				0x56
+#define CONFIG_RED_LED					0x53
+#define CONFIG_GREEN_LED				0x54
+#define CONFIG_YELLOW_LED				0x55
+#define CONFIG_BLUE_LED					0x56

--- a/include/configs/pumpkin-mbm2.h
+++ b/include/configs/pumpkin-mbm2.h
@@ -63,12 +63,13 @@
 
 #define KUBOS_UPGRADE_DEVICE 0
 #define KUBOS_UPGRADE_PART   1
+#define KUBOS_UPGRADE_STORAGE CONFIG_SYS_LOAD_ADDR /* Temporary SDRAM storage location */
 
 /* DFU Configuration */
 #define DFU_ALT_INFO_MMC \
 	"dfu_alt_info_mmc=" 		\
 	"kernel fat 1 1;" 		\
-	"rootfs part 1 2; " \
+	"rootfs part 1 2;" \
 	"uboot fat 1 1;" \
 	"dtb fat 1 1" \
 	"\0"
@@ -79,7 +80,6 @@
 #define DFU_ALT_INFO_NOR ""
 #endif /* CONFIG_UPDATE_KUBOS */
 
-/* Boot from eMMC */
 #define CONFIG_BOOTCOMMAND \
 	"setenv bootargs console=ttyS0,115200 root=/dev/mmcblk${boot_dev}p2 ext4 rootwait; " \
 	"fatload mmc ${boot_dev}:1 ${fdtaddr} /pumpkin-mbm2.dtb; " \


### PR DESCRIPTION
A few different things got changed in this PR:

- Various parameters got added to the setup for Kubos upgrading because things like upgrade device and upgrade storage area are board-specific
- dfu_mmc.c - Updated to correctly allow files to be placed on not-the-first mmc device (eMMC is actually the second mmc device and absolutely the one we want to be applying updates to...)
- The `boot_dev` envar got added. This allows us to more easily change where the kernel and rootfs are running from (SD card vs eMMC). In order to flash the eMMC, we must be running on the SD card, so this will be important.
