### PR TITLE
Increasing copy size for DTB file

### DIFF
--- a/include/configs/at91sam9g20isis.h
+++ b/include/configs/at91sam9g20isis.h
@@ -191,8 +191,8 @@
 #define SMALL_SECT_SIZE   0x1000
 #define LARGE_SECT_SIZE   0x10000
 /* (bootstrap + u-boot + dtb (+ altOS) in flash) + (env + linux in mmc) */
-/* Copy .dtb file (NORFLASH @ 0x70000, size = 0x5000) and kernel (SD card, partition 5) into SDRAM, then boot them */
-#define CONFIG_BOOTCOMMAND	"cp.b 0x10070000 0x21800000 0x5000; " \
+/* Copy .dtb file (NORFLASH @ 0x70000, size = 0x10000) and kernel (SD card, partition 5) into SDRAM, then boot them */
+#define CONFIG_BOOTCOMMAND	"cp.b 0x10070000 0x21800000 0x10000; " \
 				"fatload mmc 0:5 0x2187FF58 kernel; " \
 				"bootm 0x2187FF58 - 0x21800000"
 /* Define the initial console connection and rootfs location */


### PR DESCRIPTION
The device tree binary for the iOBC has exceeded the size currently defined to U-Boot (0x5000, 20480 bytes). Increasing the size to be up to one full flash sector (0x10000).